### PR TITLE
Update the readme for Brave Browser users

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,4 @@ By running this script, `generateVapidKeys.js` will be executed, and the VAPID k
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-
-
-
+Note: If you are using the Brave Browser, you'll need to enable push messaging in your settings. For more details, please refer to this [Stack Overflow post](https://stackoverflow.com/a/69624651/11703800).


### PR DESCRIPTION
Update the readme for Brave Browser users. There is a privacy setting in Brave browser that blocks this by default (`Use Google services for push messaging`)

Error:
![image](https://github.com/user-attachments/assets/9601a9dd-58ed-444f-b5e3-750c83919017)